### PR TITLE
Update to sbt-dependency-graph 0.7.5 and sbt 0.13.8

### DIFF
--- a/project.sbt
+++ b/project.sbt
@@ -4,7 +4,7 @@ name := "sbt-dependency-graph-sugar"
 
 organization := "com.gilt"
 
-version := "0.7.4"
+version := "0.7.5"
 
 homepage := Some(url("http://github.com/gilt/sbt-dependency-graph-sugar"))
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8


### PR DESCRIPTION
0.7.5 fixes jrudolph/sbt-dependency-graph#67 which add support for sbt 0.13.8